### PR TITLE
チャット、FAQ履歴の二重登録と日本時間修正、要約失敗対応

### DIFF
--- a/app/modules/chat/routes.py
+++ b/app/modules/chat/routes.py
@@ -6,7 +6,6 @@ from app.modules.rag.rag_utils import perform_vector_search
 from app.modules.logging.vector_search_logger import log_no_result_search
 from app.modules.logging.user_activity_logger import log_user_activity  # ←追加
 import uuid
-from datetime import datetime, timezone
 from app.models import db, ChatHistory
 
 chat_bp = Blueprint('chat', __name__, template_folder='templates')
@@ -44,19 +43,7 @@ def index():
         log_user_activity(current_user.id, action="質問送信", details=user_message)
 
         # チャット履歴をデータベースに保存（save_chat_history を再追加）
-        save_chat_history(user_message, assistant_response, title=title)
-
-        # ChatHistoryにも履歴を保存（DBでの永続化）
-        chat_history_entry = ChatHistory(
-            thread_id=thread_id,
-            user_id=current_user.id,
-            title=title,
-            user_message=user_message,
-            assistant_message=assistant_response,
-            created_at=datetime.now(timezone.utc)
-        )
-        db.session.add(chat_history_entry)
-        db.session.commit()
+        save_chat_history(thread_id, current_user.id, user_message, assistant_response, title=title)
 
         source_details = source_info
 

--- a/app/modules/faq/routes.py
+++ b/app/modules/faq/routes.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request, jsonify, render_template, abort, flash, se
 from flask_login import login_required, current_user
 from app.modules.faq.faq_query import find_similar_questions
 from app.modules.history.history_query import save_chat_history
+from app.models import db, ChatHistory
 
 faq_bp = Blueprint('faq', __name__, template_folder='templates')
 
@@ -28,7 +29,9 @@ def faq_help():
         session['faq_messages'].append({'role': 'assistant', 'content': assistant_message})
         session.modified = True
 
-        save_chat_history(user_input, assistant_message)
+        # FAQ用に固定のthread_id（例: 0）を使用する
+        faq_thread_id = 0
+        save_chat_history(faq_thread_id, current_user.id, user_input, assistant_message)
 
         return jsonify({"answer": assistant_message}), 200
 
@@ -37,6 +40,24 @@ def faq_help():
 @faq_bp.route('/faq-reset', methods=['POST'])
 @login_required
 def reset_faq_chat():
-    session.pop('faq_messages', None)
-    flash('チャット履歴をリセットしました。', 'info')
-    return jsonify({'status': 'success'}), 200
+    faq_thread_id = 0  # FAQ専用のthread_idを指定
+
+    try:
+        # DBから該当のFAQ履歴を削除
+        ChatHistory.query.filter_by(
+            thread_id=faq_thread_id,
+            user_id=current_user.id
+        ).delete()
+
+        db.session.commit()
+
+        # sessionもクリア（オプション）
+        session.pop('faq_messages', None)
+
+        flash('FAQチャット履歴をリセットしました。', 'info')
+        return jsonify({'status': 'success'}), 200
+
+    except Exception as e:
+        db.session.rollback()
+        flash('FAQ履歴のリセットに失敗しました。', 'danger')
+        return jsonify({'status': 'error', 'message': str(e)}), 500

--- a/app/modules/history/history_query.py
+++ b/app/modules/history/history_query.py
@@ -2,6 +2,8 @@ from app.database import db
 from app.models import ChatHistory
 from flask_login import current_user
 from app.modules.logging.user_activity_logger import log_user_activity  # 追加
+from pytz import timezone as pytz_timezone
+from datetime import datetime
 
 def get_chat_histories(limit=10):
     histories = ChatHistory.query.order_by(ChatHistory.created_at.desc()).limit(limit).all()
@@ -15,11 +17,15 @@ def get_chat_history_detail(history_id):
     log_user_activity(current_user.id, action="履歴詳細閲覧", details=f"履歴ID: {history_id}")
     return history
 
-def save_chat_history(user_message, assistant_message, title=None):
+def save_chat_history(thread_id, user_id, user_message, assistant_message, title=None):
+    jst = pytz_timezone('Asia/Tokyo')
     history_entry = ChatHistory(
+        thread_id=thread_id,
+        user_id=user_id,
         title=title if title else user_message[:20],
         user_message=user_message,
-        assistant_message=assistant_message
+        assistant_message=assistant_message,
+        created_at=datetime.now(jst)
     )
     db.session.add(history_entry)
     db.session.commit()

--- a/app/openai_utils.py
+++ b/app/openai_utils.py
@@ -9,6 +9,7 @@ openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 def get_chatgpt_response(user_id, messages, use_rag_search=True):
     start_time = time.time()
     last_message = messages[-1]['content']
+    from app.modules.rag.rag_utils import perform_vector_search
 
     if use_rag_search:
         rag_response, source_info = perform_vector_search(user_id, last_message)


### PR DESCRIPTION
## 1. チャット履歴の重複問題と解決方法

### 問題の概要

チャット履歴が二重に表示される問題が発生。これは履歴保存処理を異なる箇所で複数回実行していたことが原因。

### 原因の詳細

以下のように、履歴保存処理を関数呼び出しと直接データベースへの挿入の2箇所で行っていた。

```python
# 問題となったコード
save_chat_history(user_message, assistant_response, title=title)

chat_history_entry = ChatHistory(
    thread_id=thread_id,
    user_id=current_user.id,
    title=title,
    user_message=user_message,
    assistant_message=assistant_response,
    created_at=datetime.now(jst)
)
db.session.add(chat_history_entry)
db.session.commit()
```

### 解決方法

履歴保存処理を`save_chat_history`関数に統一し、スレッドID (`thread_id`) とユーザーID (`user_id`) を明示的に渡して処理を一本化。

#### 修正版の関数

```python
def save_chat_history(thread_id, user_id, user_message, assistant_message, title=None):
    jst = pytz_timezone('Asia/Tokyo')
    history_entry = ChatHistory(
        thread_id=thread_id,
        user_id=user_id,
        title=title if title else user_message[:20],
        user_message=user_message,
        assistant_message=assistant_message,
        created_at=datetime.now(jst)
    )
    db.session.add(history_entry)
    db.session.commit()
    log_user_activity(user_id, action="履歴保存", details=f"タイトル: {history_entry.title}")
```

#### 使用例

```python
# 修正後の呼び出し例
save_chat_history(thread_id, current_user.id, user_message, assistant_response, title=title)
```

### 結果

上記の修正を行うことで、チャット履歴の重複表示問題が解決され、正常な動作が確認された。



# 「\[要約失敗] name 'perform\_vector\_search' is not defined」の問題と解決方法

## 問題の概要

Slackへの通知で以下のエラーが発生した。

```
[要約失敗] name 'perform_vector_search' is not defined
```

これは`perform_vector_search`関数が未定義または正しくインポートされていないことが原因。

## 原因の詳細

このエラーは、RAG（情報検索）機能やスレッドタイトル生成処理で、ベクトル検索を行うための関数`perform_vector_search`を呼び出した際に発生した。

* `perform_vector_search`が定義されているファイル（例：`rag_utils.py`）のインポートが漏れていた。
* インポート追加後に循環インポートエラーが発生。

循環インポートエラーの例:

```
ImportError: cannot import name 'get_chatgpt_response' from partially initialized module 'app.openai_utils'
```

## 解決方法

### 循環インポートの回避

循環インポートを回避するために、関数内でローカルインポートを利用する。

#### 修正例

```python
# openai_utils.py内の修正版
def generate_thread_title(query):
    from app.modules.rag.rag_utils import perform_vector_search  # ローカルインポート

    search_results = perform_vector_search(query)
    title = get_chatgpt_response(search_results)
    return title
```

### 確認事項

* 関数`perform_vector_search`が存在していることを確認。
* 必要に応じて、共通関数は専用モジュールに移動し、モジュール構成を整理。

## 結果

上記の対応を実施後、エラーは解消され正常に動作が確認された。
