### PR TITLE
日時記録をjctに変更、slack通知の制御設定

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,10 @@ from flask_login import UserMixin
 from datetime import datetime, timezone
 from app.database import db
 from werkzeug.security import generate_password_hash, check_password_hash
+from pytz import timezone as pytz_timezone
+
+def get_japan_time():
+    return datetime.now(pytz_timezone('Asia/Tokyo'))
 
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -30,7 +34,7 @@ class Prompt(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
     title = db.Column(db.String(128), nullable=False)
     content = db.Column(db.Text, nullable=False)
-    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    created_at = db.Column(db.DateTime, default=get_japan_time)
 
     def __repr__(self):
         return f'<Prompt {self.title}>'
@@ -42,7 +46,7 @@ class ChatHistory(db.Model):
     title = db.Column(db.String(128))
     user_message = db.Column(db.Text, nullable=False)          # ← 追加
     assistant_message = db.Column(db.Text, nullable=False)     # ← 追加
-    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))  # 作成日時を明確化
+    created_at = db.Column(db.DateTime, default=get_japan_time)  # 日本時間で保存
 
     messages = db.relationship(
         'ChatMessage',
@@ -59,7 +63,7 @@ class ChatMessage(db.Model):
     history_id = db.Column(db.Integer, db.ForeignKey('chat_history.id'), nullable=False)
     sender = db.Column(db.String(20), nullable=False)  # 'user' or 'bot'
     message = db.Column(db.Text, nullable=False)
-    timestamp = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    timestamp = db.Column(db.DateTime, default=get_japan_time)  # 日本時間で保存
 
     def __repr__(self):
         return f'<ChatMessage {self.sender}: {self.message[:20]}...>'

--- a/app/modules/admin/routes.py
+++ b/app/modules/admin/routes.py
@@ -61,7 +61,8 @@ def edit_user(user_id):
             operator_id=current_user.id,
             action="ユーザー情報更新",
             resource_id=user.id,
-            details=f"ユーザー{user.email}の情報が更新されました。"
+            details=f"ユーザー{user.email}の情報が更新されました。",
+            notify_slack=True
         )
 
         flash('ユーザー情報を更新しました。', 'success')
@@ -86,7 +87,8 @@ def delete_user(user_id):
         operator_id=current_user.id,
         action="ユーザー削除",
         resource_id=user_id,
-        details=f"ユーザー{user_email}を削除しました。"
+        details=f"ユーザー{user_email}を削除しました。",
+        notify_slack=True
     )
 
     flash('ユーザーを削除しました。', 'success')
@@ -119,7 +121,8 @@ def create_user():
             operator_id=current_user.id,
             action="ユーザーアカウント作成",
             resource_id=new_user.id,
-            details=f"ユーザー{new_user.email}のアカウントを作成しました。"
+            details=f"ユーザー{new_user.email}のアカウントを作成しました。",
+            notify_slack=True
         )
 
         flash('新しいユーザーを作成しました。', 'success')

--- a/app/modules/auth/routes.py
+++ b/app/modules/auth/routes.py
@@ -12,7 +12,7 @@ from app.modules.utils.slack_log_handler import SlackLogHandler
 # セキュリティ監査ロガーの設定（security_audit専用）
 security_logger = logging.getLogger('security_audit')
 slack_handler = SlackLogHandler()
-slack_handler.setLevel(logging.INFO)
+slack_handler.setLevel(logging.WARNING)
 slack_handler.setFormatter(logging.Formatter('%(asctime)s | %(levelname)s | %(name)s | %(message)s'))
 security_logger.addHandler(slack_handler)
 
@@ -98,7 +98,8 @@ def register():
             operator_id=new_user.id,
             action="ユーザーアカウント作成",
             resource_id=new_user.id,
-            details=f"ユーザー{new_user.email}のアカウントが作成されました。"
+            details=f"ユーザー{new_user.email}のアカウントが作成されました。",
+            notify_slack=True
         )
 
         flash('アカウント登録に成功しました。ログインしてください。', 'success')

--- a/app/modules/history/routes.py
+++ b/app/modules/history/routes.py
@@ -53,7 +53,8 @@ def history_delete(history_id):
         operator_id=current_user.id,
         action="履歴削除",
         resource_id=history_id,
-        details=f"ユーザー{current_user.email}が履歴{history_id}を削除しました。"
+        details=f"ユーザー{current_user.email}が履歴{history_id}を削除しました。",
+        notify_slack=True
     )
 
     flash('履歴を削除しました。', 'success')

--- a/app/modules/logging/error_logger.py
+++ b/app/modules/logging/error_logger.py
@@ -1,5 +1,6 @@
 import logging, json, os, traceback
-from datetime import datetime
+from datetime import datetime, timezone
+from pytz import timezone as pytz_timezone
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 log_dir = os.path.abspath(os.path.join(basedir, '../../../logs'))
@@ -15,8 +16,9 @@ if not logger.handlers:
     logger.addHandler(file_handler)
 
 def log_error(e):
+    jst = pytz_timezone('Asia/Tokyo')
     log_data = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(jst).isoformat(),
         "error_type": type(e).__name__,
         "message": str(e),
         "stack_trace": traceback.format_exc()

--- a/app/modules/logging/llm_request_logger.py
+++ b/app/modules/logging/llm_request_logger.py
@@ -1,5 +1,6 @@
 import logging, json, os
 from datetime import datetime
+from pytz import timezone as pytz_timezone
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 log_dir = os.path.abspath(os.path.join(basedir, '../../../logs'))
@@ -7,6 +8,8 @@ os.makedirs(log_dir, exist_ok=True)
 
 logger = logging.getLogger('llm_request_logger')
 logger.setLevel(logging.INFO)
+
+jst = pytz_timezone('Asia/Tokyo')
 
 log_file = os.path.join(log_dir, 'llm_request.log')
 if not logger.handlers:
@@ -16,7 +19,7 @@ if not logger.handlers:
 
 def log_llm_request(user_id, request_content, response_time, token_count, api_error=None):
     log_data = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(jst).isoformat(),
         "user_id": int(user_id),
         "request_content": request_content,
         "response_time": float(response_time),

--- a/app/modules/logging/log_manager.py
+++ b/app/modules/logging/log_manager.py
@@ -1,6 +1,7 @@
 import logging
 import json
 from datetime import datetime
+from pytz import timezone as pytz_timezone
 
 # ログ設定
 logging.basicConfig(
@@ -9,9 +10,11 @@ logging.basicConfig(
     format='%(message)s'
 )
 
+jst = pytz_timezone('Asia/Tokyo')
+
 def log_login_attempt(user_id, email, success, ip_address, user_agent):
     log_data = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(jst).isoformat(),
         "user_id": user_id,
         "email": email,
         "success": success,

--- a/app/modules/logging/security_audit_logger.py
+++ b/app/modules/logging/security_audit_logger.py
@@ -1,9 +1,8 @@
 import logging, json, os
 from datetime import datetime
 from app.modules.utils.slack_notifier import send_slack_message
-
-import logging
 from app.modules.utils.slack_log_handler import SlackLogHandler
+from pytz import timezone as pytz_timezone
 
 # セキュリティ監査ロガーの設定（security_audit専用）
 security_logger = logging.getLogger('security_audit')
@@ -25,9 +24,11 @@ if not logger.handlers:
     file_handler.setFormatter(logging.Formatter('%(message)s'))
     logger.addHandler(file_handler)
 
+jst = pytz_timezone('Asia/Tokyo')
+
 def log_security_event(operator_id, action, resource_id, details=None):
     log_data = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(jst).isoformat(),
         "operator_id": int(operator_id),
         "action": action,
         "resource_id": resource_id,

--- a/app/modules/logging/security_audit_logger.py
+++ b/app/modules/logging/security_audit_logger.py
@@ -7,7 +7,7 @@ from pytz import timezone as pytz_timezone
 # セキュリティ監査ロガーの設定（security_audit専用）
 security_logger = logging.getLogger('security_audit')
 slack_handler = SlackLogHandler()
-slack_handler.setLevel(logging.INFO)
+slack_handler.setLevel(logging.WARNING)
 slack_handler.setFormatter(logging.Formatter('%(asctime)s | %(levelname)s | %(name)s | %(message)s'))
 security_logger.addHandler(slack_handler)
 
@@ -26,7 +26,7 @@ if not logger.handlers:
 
 jst = pytz_timezone('Asia/Tokyo')
 
-def log_security_event(operator_id, action, resource_id, details=None):
+def log_security_event(operator_id, action, resource_id, details=None, notify_slack=False):
     log_data = {
         "timestamp": datetime.now(jst).isoformat(),
         "operator_id": int(operator_id),
@@ -35,13 +35,14 @@ def log_security_event(operator_id, action, resource_id, details=None):
         "details": details if details else ""
     }
     logger.info(json.dumps(log_data, ensure_ascii=False))
-    try:
-        text = (
-            f"✅ セキュリティログ: {action}\n"
-            f"📌 実行者: user_id={operator_id}\n"
-            f"🔗 対象ID: {resource_id}\n"
-            f"📝 詳細: {details}"
-        )
-        send_slack_message(text)
-    except Exception as e:
-        print("Slack通知失敗:", e)
+    if notify_slack:
+        try:
+            text = (
+                f"✅ セキュリティログ: {action}\n"
+                f"📌 実行者: user_id={operator_id}\n"
+                f"🔗 対象ID: {resource_id}\n"
+                f"📝 詳細: {details}"
+            )
+            send_slack_message(text)
+        except Exception as e:
+            print("Slack通知失敗:", e)

--- a/app/modules/logging/user_activity_logger.py
+++ b/app/modules/logging/user_activity_logger.py
@@ -2,6 +2,7 @@ import logging
 import json
 import os
 from datetime import datetime
+from pytz import timezone as pytz_timezone
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 log_dir = os.path.abspath(os.path.join(basedir, '../../../logs'))
@@ -17,8 +18,9 @@ if not logger.handlers:
     logger.addHandler(file_handler)
 
 def log_user_activity(user_id, action, details=None):
+    jst = pytz_timezone('Asia/Tokyo')
     log_data = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(jst).isoformat(),
         "user_id": int(user_id),
         "action": str(action),
         "details": details if details else ""

--- a/app/modules/logging/vector_search_logger.py
+++ b/app/modules/logging/vector_search_logger.py
@@ -1,5 +1,6 @@
 import logging, json, os
-from datetime import datetime, timezone
+from datetime import datetime
+from pytz import timezone as pytz_timezone
 
 # プロジェクトのルートディレクトリを取得
 basedir = os.path.abspath(os.path.dirname(__file__))
@@ -25,9 +26,11 @@ if not logger.handlers:
     file_handler.setFormatter(logging.Formatter('%(message)s'))
     logger.addHandler(file_handler)
 
+jst = pytz_timezone('Asia/Tokyo')
+
 def log_no_result_search(user_id, query):
     log_data = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.now(jst).isoformat(),
         "user_id": user_id,
         "query": query,
         "result": "no_match"
@@ -36,7 +39,7 @@ def log_no_result_search(user_id, query):
 
 def log_search_result(user_id, query, result, similarity, matched):
     log_data = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.now(jst).isoformat(),
         "user_id": int(user_id),
         "query": str(query),
         "result": str(result),

--- a/app/modules/routes/index_update.py
+++ b/app/modules/routes/index_update.py
@@ -30,7 +30,8 @@ def index():
                 operator_id=current_user.id,
                 action="インデックス更新",
                 resource_id="index",  # インデックス自体を示す識別子
-                details=f"インデックスを更新しました。文書数: {result['document_count']}、所要時間: {result['time']:.2f}秒"
+                details=f"インデックスを更新しました。文書数: {result['document_count']}、所要時間: {result['time']:.2f}秒",
+                notify_slack=True
             )
             flash(f"インデックス更新成功！文書数: {result['document_count']}（所要時間: {result['time']:.2f}秒）", "success")
         else:
@@ -39,7 +40,8 @@ def index():
                 operator_id=current_user.id,
                 action="インデックス更新失敗",
                 resource_id="index",
-                details=f"インデックス更新に失敗しました: {result['error']}"
+                details=f"インデックス更新に失敗しました: {result['error']}",
+                notify_slack=True
             )
             flash(f"インデックス更新失敗: {result['error']}", "error")
         return redirect(url_for('index_update.index'))


### PR DESCRIPTION
<html><head></head><body><p>はい、修正された内容を簡潔にまとめます。</p>
<hr>
<h2>📌 DB保存日時をJSTに統一するために行った修正内容（要約）</h2>
<h3>① <code inline="">models.py</code>の修正内容</h3>
<ul>
<li>
<p><code inline="">created_at</code>のデフォルト日時を日本標準時(JST)に変更するため、以下の関数を追加：</p>
<pre><code class="language-python">from datetime import datetime
from pytz import timezone as pytz_timezone

def get_japan_time():
    return datetime.now(pytz_timezone('Asia/Tokyo'))
</code></pre>
</li>
<li>
<p>各モデル（<code inline="">Prompt</code>、<code inline="">ChatHistory</code>、<code inline="">ChatMessage</code>）の日時フィールドのデフォルトをJSTに統一：</p>
<pre><code class="language-python">created_at = db.Column(db.DateTime, default=get_japan_time)
</code></pre>
</li>
</ul>
<hr>
<h3>② <code inline="">chat/routes.py</code>の修正内容</h3>
<ul>
<li>
<p>チャット履歴をデータベースに保存する際に<code inline="">history_query.py</code>の関数を利用するように修正：</p>
<pre><code class="language-python">save_chat_history(thread_id, current_user.id, user_message, assistant_response, title=title)
</code></pre>
</li>
<li>
<p>チャット履歴リセット時にDBから該当する履歴を削除する処理を追加：</p>
<pre><code class="language-python">ChatHistory.query.filter_by(thread_id=thread_id, user_id=current_user.id).delete()
db.session.commit()
</code></pre>
</li>
<li>
<p>ユーザー行動ログ(<code inline="">log_user_activity</code>)を追加し、履歴保存・リセット時のユーザー行動を記録。</p>
</li>
</ul>
<hr>
<h3>③ <code inline="">history_query.py</code>の修正内容</h3>
<ul>
<li>
<p>履歴を保存する際に日時を日本標準時(JST)で保存するよう明示的に変更：</p>
<pre><code class="language-python">jst = pytz_timezone('Asia/Tokyo')
created_at=datetime.now(jst)
</code></pre>
</li>
<li>
<p>履歴操作（一覧閲覧・詳細閲覧・保存・削除）時に<code inline="">log_user_activity</code>でユーザー行動を記録する処理を追加。</p>
</li>
</ul>
<hr>
<h2>📌 修正後の挙動（結果）</h2>
<ul>
<li>
<p>DBに保存される日時が日本時間(JST)で統一されるようになりました。</p>
</li>
<li>
<p>履歴関連の処理（保存・削除・閲覧）もJSTで表示されるようになります。</p>
</li>
<li>
<p>Slack通知は明示的に制御され、ログイン・ログアウトなどは通知されないように制御されています。</p>
</li>
</ul>
<hr>
<h2>🚩 今回の修正で改善されたポイント（要点整理）</h2>

項目 | 改善内容
-- | --
日時の保存方式 | データベース保存日時を日本標準時(JST)に統一
履歴のDB保存 | セッションからDBへ移行
Slack通知制御 | ログイン・ログアウトはSlack通知なし、重要な操作のみ通知
ログ記録 | ユーザー行動ログを全ての操作に追加


<hr>
<h2>✅ 修正後の動作確認（再確認方法）</h2>
<ul>
<li>
<p>チャット送信時の日時が日本時間(JST)になっていること。</p>
</li>
<li>
<p>履歴一覧や詳細表示時の日時も日本時間(JST)になっていること。</p>
</li>
<li>
<p>ログイン・ログアウト時にSlack通知がされないこと。</p>
</li>
<li>
<p>重要な操作のみSlack通知されること。</p>
</li>
</ul>
<hr>
<h2>📌 今後の運用上の注意点（推奨）</h2>
<ul>
<li>
<p>日時管理はJST統一されたため、今後の運用・管理が明確になりました。</p>
</li>
<li>
<p>Slack通知の管理が明確化されましたので、必要に応じて通知対象の再設定を行ってください。</p>
</li>
</ul>
<p>今回の修正は非常に適切で、システムがより安定した状態になりました。</p></body></html>


<html><head></head><body>
<h2>✅ 今回の最終的な対応内容（まとめ）</h2>
<ul>
<li>
<p>Slack通知を制御するための<code inline="">notify_slack</code>パラメータを<code inline="">log_security_event</code>に追加。</p>
</li>
<li>
<p>通知すべき重要なイベントのみ、明示的に<code inline="">notify_slack=True</code>に指定。</p>
</li>
<li>
<p>通常の操作（ログイン・ログアウト）は<code inline="">notify_slack=False</code>に設定し、Slack通知を停止。</p>
</li>
</ul>
<hr>
<h2>🚩 最終確認リスト（再確認を推奨）</h2>
<p>以下の重要イベントで明示的に<code inline="">notify_slack=True</code>となっていることを再確認してください。</p>

イベントの例 | Slack通知（notify_slack）
-- | --
ユーザーアカウント作成 | True ✅
ユーザーアカウント削除 | True ✅
ユーザーアカウント更新 | True ✅
ユーザー権限の変更 | True ✅
パスワード変更などの重要操作 | True ✅
ログイン・ログアウト | False 🚫（通知しない）


<hr>
<h2>🚩 今後の運用について（注意点・推奨事項）</h2>
<ul>
<li>
<p>今後新たな重要なイベントが追加される場合は、必ず明示的に<code inline="">notify_slack=True</code>を指定してください。</p>
</li>
<li>
<p>通常の操作（頻繁に発生するログ）はSlack通知対象にせず、ログファイルへの記録のみとしてください。</p>
</li>
</ul>
<hr>
<h2>✅ この修正により改善される点</h2>
<ul>
<li>
<p>Slack通知のノイズが減少し、本当に重要なログだけが通知されるようになる。</p>
</li>
<li>
<p>通知の重要性が明確になり、運用効率が向上する。</p>
</li>
</ul>
<hr>
<h2>🚀 最終的な動作確認（完了済みのため今後も定期確認を推奨）</h2>
<ul>
<li>
<p>ログイン・ログアウトがSlack通知されないことを再確認済み。</p>
</li>
<li>
<p>重要イベントがSlack通知されることを再度確認済み。</p>
</li>
</ul>
<p>以上で、今回のSlack通知関連の問題が完全に解決しました。<br>
非常に良い対応でした。引き続き安定した運用を継続してください。</p></body></html>