### PR TITLE
履歴一覧画面における権限による削除ボタンの表示制御

### DIFF
--- a/app/templates/history/history_list.html
+++ b/app/templates/history/history_list.html
@@ -22,10 +22,13 @@
                                 <a href="{{ url_for('history.history_detail', history_id=history.id) }}">
                                     {{ history.created_at.strftime('%Y-%m-%d %H:%M') }} - {{ history.title }}
                                 </a>
-                                <!-- 削除ボタン（Adminのみ） -->
+                                {# ↓ 削除ボタンを完全に非表示にする場合 ↓ #}
+                                {% if current_user.has_permission('delete_history') %}
                                 <form action="{{ url_for('history.history_delete', history_id=history.id) }}" method="POST" style="display:inline;">
-                                    <button class="btn btn-danger btn-sm" {% if not current_user.has_permission('delete_history') %}disabled{% endif %}>削除</button>
+                                    <button class="btn btn-danger btn-sm">削除</button>
                                 </form>
+                                {% endif %}
+                                {# ↑ ここまで修正 ↑ #}
                             </li>
                         {% endfor %}
                     </ul>


### PR DESCRIPTION
<html><head></head><body><p>今回の <strong>履歴一覧画面における権限による削除ボタンの表示制御</strong> について実施した対応内容を以下にまとめます。</p>
<hr>
<h2>🚩 要望内容（再掲）</h2>
<ul>
<li>
<p>チャット履歴一覧画面で、<br>
一般ユーザー（User権限）の場合は削除ボタンを非表示にし、<br>
管理者ユーザー（Admin権限）の場合のみ削除ボタンを表示したい。</p>
</li>
</ul>
<hr>
<h2>📌 実施した修正内容（HTMLテンプレート修正）</h2>
<p><strong>テンプレート:</strong><br>
<code inline="">templates/history/history_list.html</code></p>
<h3>🔸 修正前のコード（問題点）</h3>
<pre><code class="language-html">&lt;!-- 非活性にするだけで非表示にならない --&gt;
&lt;button class="btn btn-danger btn-sm"
    {% if not current_user.has_permission('delete_history') %}disabled{% endif %}&gt;
    削除
&lt;/button&gt;
</code></pre>
<hr>
<h3>🔸 修正後のコード（完全に非表示に変更）</h3>
<pre><code class="language-html">{% if current_user.has_permission('delete_history') %}
&lt;form action="{{ url_for('history.history_delete', history_id=history.id) }}" method="POST" style="display:inline;"&gt;
    &lt;button class="btn btn-danger btn-sm"&gt;削除&lt;/button&gt;
&lt;/form&gt;
{% endif %}
</code></pre>
<hr>
<h2>📌 対応後の挙動（確認済み）</h2>

ユーザー権限 | 削除ボタン表示
-- | --
一般ユーザー（User） | ❌ 非表示
管理者ユーザー（Admin） | ✅ 表示


<hr>
<p>これで今回の問題は完全に解決しました✨<br>
またご不明な点があればいつでもご相談ください！</p></body></html>